### PR TITLE
Add module metadata URI

### DIFF
--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -224,6 +224,10 @@ interface IModule {
     function onInstall(bytes calldata data) external;
     function onUninstall(bytes calldata data) external;
     function isModuleType(uint256 typeID) external view returns(bool);
+
+    /// @notice A distinct Uniform Resource Identifier (URI) for the module metadata.
+    /// @dev URIs are defined in RFC 3986.
+    function metadataURI() external view returns (string);
 }
 ```
 


### PR DESCRIPTION
Adding a function to return a metadata URI similar to ERC-721 tokenURI. This would allow frontends to easily access the metadata of modules in a standardized form.

Open question: should we also standardize the metadata schema? One idea could be (similar to 721):

```
json
{
    "title": "Module Metadata",
    "type": "object",
    "properties": {
        "name": {
            "type": "string",
            "description": "Name of the module",
        },
        "description": {
            "type": "string",
            "description": "Describes the module",
        },
        "image": {
            "type": "string",
            "description": "A URI pointing to a resource with mime type image/* representing an icon to be used for the module",
        },
        "additional_data": {
            "type": "object",
            "description": "An array of additional data that can be used to display on a frontend",
            "required": false
        }
    }
}
```
