### PR TITLE
Remove not-needed 4337 references

### DIFF
--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -31,12 +31,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Definitions
 
-- **Smart account** - An [ERC-4337](./eip-4337.md) compliant smart contract account that has a modular architecture.
+- **Smart account** - A smart contract account that has a modular architecture.
 - **Module** - A smart contract with self-contained smart account functionality.
-  - Validator: A module used during the ERC-4337 validation flow to determine if a `PackedUserOperation` is valid.
+  - Validator: A module used during the validation phase to determine if a transaction is valid and should be executed on the account.
   - Executor: A module that can execute transactions on behalf of the smart account via a callback.
   - Fallback Handler: A module that can extend the fallback functionality of a smart account.
-- **Entrypoint** - A trusted singleton contract according to ERC-4337 specifications.
+- **Entrypoint** - A trusted singleton contract according to [ERC-4337](./eip-4337.md) specifications.
 
 ### Account
 

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -42,7 +42,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 #### Validation
 
-This standard does not dictate how validator selection is implemented. However, should a smart account encode validator selection mechanisms in data fields passed to the validator (i.e. in `userOp.signature` if used with ERC-4337), the smart account MUST sanitize the affected values before invoking the validator.
+This standard does not dictate how validator selection is implemented. However, should a smart account encode validator selection mechanisms in data fields passed to the validator (e.g. in `userOp.signature` if used with ERC-4337), the smart account MUST sanitize the affected values before invoking the validator.
 
 The smart account's validation function SHOULD return the return value of the validator.
 
@@ -57,7 +57,7 @@ interface IExecution {
      * @param mode The encoded execution mode of the transaction. See ModeLib.sol for details
      * @param executionCalldata The encoded execution call data
      *
-     * MUST ensure adequate authorization control: i.e. onlyEntryPointOrSelf if used with ERC-4337
+     * MUST ensure adequate authorization control: e.g. onlyEntryPointOrSelf if used with ERC-4337
      * If a mode is requested that is not supported by the Account, it MUST revert
      */
     function execute(bytes32 mode, bytes calldata executionCalldata) external;
@@ -86,7 +86,7 @@ The account MAY also implement the following function in accordance with ERC-433
  * @param userOp PackedUserOperation struct (see ERC-4337 v0.7+)
  * @param userOpHash The hash of the PackedUserOperation struct
  *
- * MUST ensure adequate authorization control: i.e. onlyEntryPointOrSelf
+ * MUST ensure adequate authorization control: i.e. onlyEntryPoint
  */
 function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external;
 ```
@@ -239,7 +239,7 @@ interface IModule {
      * @dev This function is called by the smart account during installation of the module
      * @param data arbitrary data that may be required on the module during `onInstall` initialization
      *
-     * MUST revert on error (i.e. if module is already enabled)
+     * MUST revert on error (e.g. if module is already enabled)
      */
     function onInstall(bytes calldata data) external;
 
@@ -378,7 +378,7 @@ A full interface of a smart account can be found in [`IMSA.sol`](../assets/eip-7
 Needs more discussion. Some initial considerations:
 
 - Implementing `delegatecall` executions on a smart account must be considered carefully. Note that smart accounts implementing `delegatecall` must ensure that the target contract is safe, otherwise security vulnerabilities are to be expected.
-- The `onInstall` and `onUninstall` functions on modules may lead to unexpected callbacks (i.e. reentrancy). Account implementations should consider this by implementing adequate protection routines. Furthermore, modules could maliciously revert on `onUninstall` to stop the account from uninstalling a module and removing it from the account.
+- The `onInstall` and `onUninstall` functions on modules may lead to unexpected callbacks (e.g. reentrancy). Account implementations should consider this by implementing adequate protection routines. Furthermore, modules could maliciously revert on `onUninstall` to stop the account from uninstalling a module and removing it from the account.
 - For modules types where only a single module is active at one time (e.g. fallback handlers), calling `installModule` on a new module will not properly uninstall the previous module, unless this is properly implemented. This could lead to unexpected behavior if the old module is then added again with left over state.
 - Insufficient authorization control in fallback handlers can lead to unauthorized executions.
 - Malicious Hooks may revert on `preCheck` or `postCheck`, adding untrusted hooks may lead to a denial of service of the account.

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -42,9 +42,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 #### Validation
 
-This standard does not dictate how validator selection is implemented. However, should a smart account encode validator selection mechanisms in ERC-4337 `PackedUserOperation` fields (i.e. `userOp.signature`), the smart account MUST sanitize the affected values before invoking the validator.
+This standard does not dictate how validator selection is implemented. However, should a smart account encode validator selection mechanisms in data fields passed to the validator (i.e. in `userOp.signature` if used with ERC-4337), the smart account MUST sanitize the affected values before invoking the validator.
 
-The smart account's `validateUserOp` function SHOULD return the return value of the validator.
+The smart account's validation function SHOULD return the return value of the validator.
 
 #### Execution Behavior
 

--- a/ERCS/erc-7579.md
+++ b/ERCS/erc-7579.md
@@ -54,11 +54,10 @@ To comply with this standard, smart accounts MUST implement the execution interf
 interface IExecution {
     /**
      * @dev Executes a transaction on behalf of the account.
-     *         This function is intended to be called by ERC-4337 EntryPoint.sol
      * @param mode The encoded execution mode of the transaction. See ModeLib.sol for details
      * @param executionCalldata The encoded execution call data
      *
-     * MUST ensure adequate authorization control: i.e. onlyEntryPointOrSelf
+     * MUST ensure adequate authorization control: i.e. onlyEntryPointOrSelf if used with ERC-4337
      * If a mode is requested that is not supported by the Account, it MUST revert
      */
     function execute(bytes32 mode, bytes calldata executionCalldata) external;

--- a/assets/erc-7579/IMSA.sol
+++ b/assets/erc-7579/IMSA.sol
@@ -1,20 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.21;
 
-/// ERC-4337 (v0.7) UserOperation struct
-struct PackedUserOperation {
-    address sender;
-    uint256 nonce;
-    bytes initCode;
-    bytes callData;
-    bytes32 accountGasLimits;
-    uint256 preVerificationGas;
-    uint256 maxFeePerGas;
-    uint256 maxPriorityFeePerGas;
-    bytes paymasterAndData;
-    bytes signature;
-}
-
 interface IERC7579Account {
     // MUST be emitted when a module is installed
     event ModuleInstalled(uint256 moduleTypeId, address module);
@@ -24,11 +10,10 @@ interface IERC7579Account {
 
     /**
      * @dev Executes a transaction on behalf of the account.
-     *         This function is intended to be called by ERC-4337 EntryPoint.sol
      * @param mode The encoded execution mode of the transaction. See ModeLib.sol for details
      * @param executionCalldata The encoded execution call data
      *
-     * MUST ensure adequate authorization control: i.e. onlyEntryPointOrSelf
+     * MUST ensure adequate authorization control: e.g. onlyEntryPointOrSelf if used with ERC-4337
      * If a mode is requested that is not supported by the Account, it MUST revert
      */
     function execute(bytes32 mode, bytes calldata executionCalldata) external;
@@ -45,17 +30,6 @@ interface IERC7579Account {
     function executeFromExecutor(bytes32 mode, bytes calldata executionCalldata)
         external
         returns (bytes[] memory returnData);
-
-    /**
-     * @dev ERC-4337 validateUserOp according to ERC-4337 v0.7
-     *         This function is intended to be called by ERC-4337 EntryPoint.sol
-     * this validation function should decode / sload the validator module to validate the userOp
-     * and call it.
-     * @param userOp PackedUserOperation struct (see ERC-4337 v0.7+)
-     */
-    function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
-        external
-        returns (uint256 validSignature);
 
     /**
      * @dev ERC-1271 isValidSignature


### PR DESCRIPTION
Removing unused references/dependencies on ERC-4337. With these changes, ERC-7579 is compatible with RIP-7560, except for the `validateUserOp` function on validators.